### PR TITLE
Truncate framework related id in read model

### DIFF
--- a/src/Nvx.ConsistentAPI.TestUtils/Nvx.ConsistentAPI.TestUtils.csproj
+++ b/src/Nvx.ConsistentAPI.TestUtils/Nvx.ConsistentAPI.TestUtils.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.0.2</Version>
+        <Version>1.0.3</Version>
         <IsPackable>true</IsPackable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Nvx.ConsistentAPI.TestUtils</PackageId>

--- a/src/Nvx.ConsistentAPI.Tests/ReadModels/ReadModelMaxLengthIntegration.cs
+++ b/src/Nvx.ConsistentAPI.Tests/ReadModels/ReadModelMaxLengthIntegration.cs
@@ -1,0 +1,39 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Nvx.ConsistentAPI.Tests.ReadModels;
+
+public class ReadModelMaxLengthIntegration
+{
+  [Fact(DisplayName = "ReadModel with max length fields should not throw exceptions")]
+  public async Task Test()
+  {
+    await using var setup = await Initializer.Do();
+
+    var name = Guid.NewGuid() + GenerateRandomString(300);
+    var tenantId = Guid.NewGuid();
+    await setup
+      .Command(new RegisterOrganizationBuilding(name), tenantId: tenantId, asAdmin: true)
+      .Map(m => m.EntityId);
+    var model = await setup.ReadModels<OrganizationBuildingReadModel>(
+    queryParameters: new Dictionary<string, string[]> {{"name", [name]}},
+    tenantId: tenantId, asAdmin: true);
+    Assert.NotNull(model);
+  }
+  
+  private static string GenerateRandomString(int length)
+  {
+    const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    var result = new StringBuilder(length);
+    using var rng = RandomNumberGenerator.Create();
+    var buffer = new byte[sizeof(uint)];
+
+    for (int i = 0; i < length; i++)
+    {
+      rng.GetBytes(buffer);
+      uint num = BitConverter.ToUInt32(buffer, 0);
+      result.Append(chars[(int)(num % (uint)chars.Length)]);
+    }
+    return result.ToString();
+  }
+}

--- a/src/Nvx.ConsistentAPI/Framework/ReadModels/DatabaseHandler.cs
+++ b/src/Nvx.ConsistentAPI/Framework/ReadModels/DatabaseHandler.cs
@@ -595,7 +595,14 @@ public class DatabaseHandler<Shape> : DatabaseHandler where Shape : HasId
     try
     {
       var parameters = new DynamicParameters(rm);
-      parameters.AddDynamicParams(traceabilityFields);
+      
+      var traceabilityFieldsTruncated = traceabilityFields with { FrameworkRelatedEntityId = traceabilityFields.FrameworkRelatedEntityId.Length > StringSizes.InlinedId
+        ? new StringInfo(traceabilityFields.FrameworkRelatedEntityId).SubstringByTextElements(
+          0,
+          StringSizes.InlinedId)
+        : traceabilityFields.FrameworkRelatedEntityId };
+      parameters.AddDynamicParams(traceabilityFieldsTruncated);
+      
       foreach (var prop in stringProperties)
       {
         var strValue = prop.pi.GetValue(rm) as string;

--- a/src/Nvx.ConsistentAPI/Nvx.ConsistentAPI.csproj
+++ b/src/Nvx.ConsistentAPI/Nvx.ConsistentAPI.csproj
@@ -8,7 +8,7 @@
         <WarningsAsErrors>nullable</WarningsAsErrors>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Nvx.ConsistentAPI</PackageId>
-        <Version>1.0.2</Version>
+        <Version>1.0.3</Version>
         <Authors>NVX.ai, Eighty Data, and Consistently Eventful</Authors>
         <Description>Event Modeling framework</Description>
         <LangVersion>13</LangVersion>


### PR DESCRIPTION
In the Read Models the id is truncated, this update makes sure the Framework Related Id in the traceability fields are also truncated.