### PR TITLE
Removed null values from array being inserted into ID - Value tables

### DIFF
--- a/src/Nvx.ConsistentAPI.TestUtils/Nvx.ConsistentAPI.TestUtils.csproj
+++ b/src/Nvx.ConsistentAPI.TestUtils/Nvx.ConsistentAPI.TestUtils.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.0.4</Version>
+        <Version>1.0.5</Version>
         <IsPackable>true</IsPackable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Nvx.ConsistentAPI.TestUtils</PackageId>

--- a/src/Nvx.ConsistentAPI.Tests/StandardFlowTest.cs
+++ b/src/Nvx.ConsistentAPI.Tests/StandardFlowTest.cs
@@ -62,7 +62,6 @@ public class StandardFlowTest
     
     await setup.Command(new AddStockTags(productId, ["Cosmetics", "Food", null]));
     var unknownProductStock = await setup.ReadModel<ProductStock>(productId.ToString());
-    Assert.NotNull(unknownProductStock);
     Assert.Equal(productId.ToString(), unknownProductStock.Id);
     Assert.Equal(100, unknownProductStock.Amount);
     Assert.Equal("Unknown product", unknownProductStock.Name);

--- a/src/Nvx.ConsistentAPI.Tests/StandardFlowTest.cs
+++ b/src/Nvx.ConsistentAPI.Tests/StandardFlowTest.cs
@@ -59,13 +59,21 @@ public class StandardFlowTest
         return unit;
       })
       .Parallel();
-    
-    await setup.Command(new AddStockTags(productId, ["Cosmetics", "Food", null]));
+
+    const string validTag1 = "Cosmetics";
+    const string validTag2 = "Food";
+    await setup.Command(new AddStockTags(productId, [validTag1, validTag2, null]));
     var unknownProductStock = await setup.ReadModel<ProductStock>(productId.ToString());
+    
     Assert.Equal(productId.ToString(), unknownProductStock.Id);
     Assert.Equal(100, unknownProductStock.Amount);
     Assert.Equal("Unknown product", unknownProductStock.Name);
-
+    
+    // Validate the null tag is ignored - Read Model is clean. 
+    Assert.Equal(2, unknownProductStock.Tags.Length);
+    Assert.Contains(unknownProductStock.Tags, tag => tag.Equals(validTag1));
+    Assert.Contains(unknownProductStock.Tags, tag => tag.Equals(validTag2));
+    
     // This creates a lot of products, so the processors can start working and be checked at the end. The processor
     // fails occasionally, and it takes at least 25 seconds to recover, so this starts now and is verified at the end.
     // The test is technically flaky, but the chances of failure are abyssal.

--- a/src/Nvx.ConsistentAPI.Tests/StandardFlowTest.cs
+++ b/src/Nvx.ConsistentAPI.Tests/StandardFlowTest.cs
@@ -50,7 +50,7 @@ public class StandardFlowTest
     await setup.Command(new CreateProduct(Guid.NewGuid(), "banana", null));
 
     // Basic command handling and entity projection.
-    await setup.ReadModelNotFound<ProductStock>(productId.ToString());
+    await setup.ReadModelNotFound<ProductStock>(productId.ToString());  
     await Enumerable
       .Range(0, 20)
       .Select<int, Func<Task<Unit>>>(_ => async () =>
@@ -59,8 +59,10 @@ public class StandardFlowTest
         return unit;
       })
       .Parallel();
-
+    
+    await setup.Command(new AddStockTags(productId, ["Cosmetics", "Food", null]));
     var unknownProductStock = await setup.ReadModel<ProductStock>(productId.ToString());
+    Assert.NotNull(unknownProductStock);
     Assert.Equal(productId.ToString(), unknownProductStock.Id);
     Assert.Equal(100, unknownProductStock.Amount);
     Assert.Equal("Unknown product", unknownProductStock.Name);

--- a/src/Nvx.ConsistentAPI/Framework/ReadModels/DatabaseHandler.cs
+++ b/src/Nvx.ConsistentAPI/Framework/ReadModels/DatabaseHandler.cs
@@ -628,10 +628,9 @@ public class DatabaseHandler<Shape> : DatabaseHandler where Shape : HasId
         foreach (var batch in BatchedArrayValues(prop, rm))
         {
           var values = batch
-            .Select((value, i) => new { Index = i, Value = value })
-            .Where(x => x.Value != null)
-            .Select(x => new { rm.Id, x.Value });
-          
+            .Select(x => new { rm.Id, Value = x })
+            .Where(y => y.Value != null);
+            
           await connection.ExecuteAsync($"INSERT INTO [{propTableName}] VALUES (@Id, @Value)", values);
         }
       }

--- a/src/Nvx.ConsistentAPI/Framework/ReadModels/DatabaseHandler.cs
+++ b/src/Nvx.ConsistentAPI/Framework/ReadModels/DatabaseHandler.cs
@@ -617,6 +617,24 @@ public class DatabaseHandler<Shape> : DatabaseHandler where Shape : HasId
         parameters.Add(prop.pi.Name, clampedValue);
       }
 
+      foreach (var prop in arrayProperties)
+      {
+        foreach (var batch in BatchedArrayValues(prop, rm))
+        {
+          var values = batch
+            .Select(x => x)
+            .Where(y => y != null)
+            .ToArray();
+
+          if (values.Length == 0)
+          {
+            continue;
+          }
+          
+          parameters.Add(prop.Name, JsonConvert.SerializeObject(values));
+        }
+      }
+      
       await connection.ExecuteAsync(TraceableUpsertSql, parameters);
       foreach (var prop in arrayProperties)
       {

--- a/src/Nvx.ConsistentAPI/Framework/ReadModels/DatabaseHandler.cs
+++ b/src/Nvx.ConsistentAPI/Framework/ReadModels/DatabaseHandler.cs
@@ -627,7 +627,11 @@ public class DatabaseHandler<Shape> : DatabaseHandler where Shape : HasId
 
         foreach (var batch in BatchedArrayValues(prop, rm))
         {
-          var values = batch.Select((_, i) => new { rm.Id, Value = batch[i] });
+          var values = batch
+            .Select((value, i) => new { Index = i, Value = value })
+            .Where(x => x.Value != null)
+            .Select(x => new { rm.Id, x.Value });
+          
           await connection.ExecuteAsync($"INSERT INTO [{propTableName}] VALUES (@Id, @Value)", values);
         }
       }

--- a/src/Nvx.ConsistentAPI/Nvx.ConsistentAPI.csproj
+++ b/src/Nvx.ConsistentAPI/Nvx.ConsistentAPI.csproj
@@ -8,7 +8,7 @@
         <WarningsAsErrors>nullable</WarningsAsErrors>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Nvx.ConsistentAPI</PackageId>
-        <Version>1.0.4</Version>
+        <Version>1.0.5</Version>
         <Authors>NVX.ai, Eighty Data, and Consistently Eventful</Authors>
         <Description>Event Modeling framework</Description>
         <LangVersion>13</LangVersion>

--- a/src/TestEventModel/TestEventModel.cs
+++ b/src/TestEventModel/TestEventModel.cs
@@ -773,7 +773,9 @@ public static class TestEventModel
               stock.ProductId,
               stock.ProductName,
               stock.Amount,
+#pragma warning disable CS8620 // Nullability is violated here for testing a Tag array containing null items.
               stock.Tags,
+#pragma warning restore CS8620 // Nullability is violated here for testing a Tag array containing null items.
               stock.PictureId,
               42,
               3.1416f,


### PR DESCRIPTION
During hydration, a SQL exception was picked up where null values were being inserted into a table[ID, Value] where Value is not allowed to be null. As this is a lookup table it makes no sense a null entry is made. This is most likely due to bad data in a read model rather than hydration.

This change ensures the framework ignores null values when creating these entries