### PR TITLE
Fix hydration on unparseable events

### DIFF
--- a/src/Nvx.ConsistentAPI.TestUtils/Nvx.ConsistentAPI.TestUtils.csproj
+++ b/src/Nvx.ConsistentAPI.TestUtils/Nvx.ConsistentAPI.TestUtils.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.0.12</Version>
+        <Version>1.0.13</Version>
         <IsPackable>true</IsPackable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Nvx.ConsistentAPI.TestUtils</PackageId>

--- a/src/Nvx.ConsistentAPI.TestUtils/TestSetup.cs
+++ b/src/Nvx.ConsistentAPI.TestUtils/TestSetup.cs
@@ -646,7 +646,7 @@ public class TestSetup : IAsyncDisposable
       eventStoreClient,
       model,
       1,
-      app.Services.GetRequiredService<ILogger<TestSetup>>(),
+      app.WebApp.Services.GetRequiredService<ILogger<TestSetup>>(),
       new ConsistencyStateMachine(baseUrl));
   }
 

--- a/src/Nvx.ConsistentAPI/ConsistentApp.cs
+++ b/src/Nvx.ConsistentAPI/ConsistentApp.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Builder;
+
+namespace Nvx.ConsistentAPI;
+
+public sealed class ConsistentApp(WebApplication webApp, Fetcher fetcher) : IAsyncDisposable
+{
+  public WebApplication WebApp { get; } = webApp;
+  public Fetcher Fetcher { get; } = fetcher;
+
+  public async ValueTask DisposeAsync() => await WebApp.DisposeAsync();
+
+  public void Run() => WebApp.Run();
+  public async Task StartAsync() => await WebApp.StartAsync();
+}

--- a/src/Nvx.ConsistentAPI/EventModeling.cs
+++ b/src/Nvx.ConsistentAPI/EventModeling.cs
@@ -146,7 +146,7 @@ public class EventModel
       InterestTriggers = InterestTriggers.Concat(other.InterestTriggers).ToArray()
     };
 
-  public async Task ApplyTo(WebApplication app, GeneratorSettings settings, ILogger logger)
+  public async Task<Fetcher> ApplyTo(WebApplication app, GeneratorSettings settings, ILogger logger)
   {
     var esClient = new EventStoreClient(EventStoreClientSettings.Create(settings.EventStoreConnectionString));
     var emitter = new Emitter(esClient, logger);
@@ -238,7 +238,7 @@ public class EventModel
       projectionDaemon,
       logger);
 
-    return;
+    return fetcher;
 
     static async Task TryActivateAdmin(Fetcher fetcher, GeneratorSettings settings, Emitter emitter)
     {

--- a/src/Nvx.ConsistentAPI/Framework/Entities/Fetcher.cs
+++ b/src/Nvx.ConsistentAPI/Framework/Entities/Fetcher.cs
@@ -315,19 +315,19 @@ public class Fetcher<Entity> : EntityFetcher
             (Entity entity, long rev, Option<Position> gp, DateTime? fe, DateTime? le, string? fu, string? lu),
             FetchResult<Entity>>(
             (seed.e, seed.r.DefaultValue(-1), seed.gp, seed.fe, seed.le, seed.fu, seed.lu),
-            async (r, @event) =>
+            async (acc, @event) =>
               await parser(@event)
                 .Match<ValueTask<(Entity entity, long rev, Option<Position> gp, DateTime? fe, DateTime? le, string? fu,
                   string? lu)>>(
                   async evt =>
                   {
                     var metadata = EventMetadata.TryParse(@event);
-                    var firstEventAt = r.fe ?? metadata.CreatedAt;
+                    var firstEventAt = acc.fe ?? metadata.CreatedAt;
                     var lastEventAt = metadata.CreatedAt;
-                    var firstUserSubFound = r.fu ?? metadata.RelatedUserSub;
-                    var lastUserSubFound = metadata.RelatedUserSub ?? r.lu;
+                    var firstUserSubFound = acc.fu ?? metadata.RelatedUserSub;
+                    var lastUserSubFound = metadata.RelatedUserSub ?? acc.lu;
                     return (
-                      await r.entity.Fold(
+                      await acc.entity.Fold(
                         evt,
                         metadata,
                         new RevisionFetchWrapper(fetcher, @event.OriginalEvent.Position)),
@@ -341,15 +341,15 @@ public class Fetcher<Entity> : EntityFetcher
                   () =>
                   {
                     var (createdAt, _, _, relatedUserSub, _) = EventMetadata.TryParse(@event);
-                    DateTime? firstEventAt = r.fe ?? createdAt;
+                    DateTime? firstEventAt = acc.fe ?? createdAt;
                     DateTime? lastEventAt = createdAt;
-                    var firstUserSubFound = r.fu ?? relatedUserSub;
-                    var lastUserSubFound = relatedUserSub ?? r.lu;
+                    var firstUserSubFound = acc.fu ?? relatedUserSub;
+                    var lastUserSubFound = relatedUserSub ?? acc.lu;
                     return ValueTask.FromResult(
                       (
-                        r.entity,
-                        @event.Event.EventNumber.ToInt64(),
-                        Some(@event.Event.Position),
+                        acc.entity,
+                        acc.rev,
+                        acc.gp,
                         firstEventAt,
                         lastEventAt,
                         firstUserSubFound,

--- a/src/Nvx.ConsistentAPI/Generator.cs
+++ b/src/Nvx.ConsistentAPI/Generator.cs
@@ -180,7 +180,7 @@ public static class Generator
   /// <param name="eventModel">The event model for the application.</param>
   /// <param name="corsOrigins">The allowed CORS origins.</param>
   /// <returns>A Task that results in a ConsistentApp instance.</returns>
-  public static async Task<WebApplication> GetWebApp(
+  public static async Task<ConsistentApp> GetWebApp(
     int? port,
     GeneratorSettings settings,
     EventModel eventModel,
@@ -383,7 +383,7 @@ public static class Generator
 
     var logger = app.Services.GetRequiredService<ILogger<WebApplication>>();
 
-    await merged.ApplyTo(app, settings, logger);
+    var fetcher = await merged.ApplyTo(app, settings, logger);
 
     settings.AppCustomizations.Iter(c => c(app));
 
@@ -416,7 +416,7 @@ public static class Generator
       });
     });
     app.UseSwaggerUI();
-    return app;
+    return new ConsistentApp(app, fetcher);
 
     LogEventLevel Map(LogLevel level) => level switch
     {

--- a/src/Nvx.ConsistentAPI/Nvx.ConsistentAPI.csproj
+++ b/src/Nvx.ConsistentAPI/Nvx.ConsistentAPI.csproj
@@ -8,7 +8,7 @@
         <WarningsAsErrors>nullable</WarningsAsErrors>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Nvx.ConsistentAPI</PackageId>
-        <Version>1.0.12</Version>
+        <Version>1.0.13</Version>
         <Authors>NVX.ai, Eighty Data, and Consistently Eventful</Authors>
         <Description>Event Modeling framework</Description>
         <LangVersion>13</LangVersion>


### PR DESCRIPTION
When the last event of the stream could not be parsed, the daemons would ignore the stream altogether