### PR TITLE
Honor LOG_LEVEL globally and bump version to 1.0.39

### DIFF
--- a/src/Nvx.ConsistentAPI.TestUtils/Nvx.ConsistentAPI.TestUtils.csproj
+++ b/src/Nvx.ConsistentAPI.TestUtils/Nvx.ConsistentAPI.TestUtils.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.0.38</Version>
+        <Version>1.0.39</Version>
         <IsPackable>true</IsPackable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Nvx.ConsistentAPI.TestUtils</PackageId>

--- a/src/Nvx.ConsistentAPI/Generator.cs
+++ b/src/Nvx.ConsistentAPI/Generator.cs
@@ -361,6 +361,8 @@ public static class Generator
       loggingBuilder.AddSerilog(
         new LoggerConfiguration()
           .MinimumLevel
+          .Is(Map(settings.LoggingSettings.LogLevel))
+          .MinimumLevel
           .Override("Nvx.ConsistentAPI", Map(settings.LoggingSettings.LogLevel))
           .Enrich.FromLogContext()
           .Filter.ByExcluding(logEvent =>

--- a/src/Nvx.ConsistentAPI/Nvx.ConsistentAPI.csproj
+++ b/src/Nvx.ConsistentAPI/Nvx.ConsistentAPI.csproj
@@ -8,7 +8,7 @@
         <WarningsAsErrors>nullable</WarningsAsErrors>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Nvx.ConsistentAPI</PackageId>
-        <Version>1.0.38</Version>
+        <Version>1.0.39</Version>
         <Authors>NVX.ai, Eighty Data, and Consistently Eventful</Authors>
         <Description>Event Modeling framework</Description>
         <LangVersion>13</LangVersion>


### PR DESCRIPTION
The Serilog configuration set only a namespace override for "Nvx.ConsistentAPI" without setting a global MinimumLevel, so it silently fell back to Serilog's default (Information). Because the framework-internal logger is retrieved as ILogger<WebApplication> (source context "Microsoft.AspNetCore.Builder.WebApplication"), it never matched the override — meaning debug logs emitted through the framework (including the SignalR pipeline checkpoints added in #50) were dropped even with LOG_LEVEL=debug set.

Add a global MinimumLevel.Is(...) so the configured LOG_LEVEL applies to every logger, regardless of source context. The existing namespace override is kept for compatibility but is now redundant.